### PR TITLE
BUGFIX#1: Fixed issue with Redux stack crashing 

### DIFF
--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -8,6 +8,7 @@ const middleware = [thunk];
 
 const store = createStore(rootReducer, initialState, compose(
   applyMiddleware(...middleware),
+  // Code below will cause other chrome browsers to crash if Redux extension is not installed
   // window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
 ));
 


### PR DESCRIPTION
closes #7 
The code below would cause the Redux stack to crash as well as other React components. This line of code looks for a redux application extension in the Chrome browser window and crashes the app if it is not found.

"window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()"

Commented out code in store.js so that I can use it but also so that other team mates can use the application without the Chrome Redux extension. 
Line of code below:

